### PR TITLE
Variable declaration/scoping fix for multiple flash messages

### DIFF
--- a/messages_list.js
+++ b/messages_list.js
@@ -18,7 +18,7 @@ Template.flashMessageItem.rendered = function () {
     flashMessages.update(message._id, {$set: {seen: true}});
   });
   if (message.options && message.options.autoHide) {
-    $alert = $(this.find('.alert'));
+    var $alert = $(this.find('.alert'));
     Meteor.setTimeout(function() {
         $alert.fadeOut(400, function() {
           flashMessages.remove({_id: message._id});


### PR DESCRIPTION
Assigning a value to `$alert` before declaring it automatically gives it a global scope; triggering a new flash message before the the timeout callback of a previous one had run would reassign `$alert` and cause the new message to fade.

You can reproduce the bug in the [demo](http://flash-messages-demo.meteor.com/) by running `FlashMessages.sendInfo("1"); setTimeout(function(){ FlashMessages.sendInfo("2"); }, 1000); setTimeout(function(){ FlashMessages.sendInfo("3"); }, 2000);` in the JS console.