### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To clear messages:
 
 Only the seen messages will be cleared.
 
-##Configure
+## Configure
 
 You can configure globally the way the messages behave with FlashMessages.configure (the below sample shows the default values):
 ```javascript


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
